### PR TITLE
:sparkles: Make file paths relative to directory that the psc file being ran is in

### DIFF
--- a/ps2/app.py
+++ b/ps2/app.py
@@ -1,3 +1,5 @@
+import os
+
 from ps2.symbol_table.environment import Environment
 from ps2.scan.scanner import Scanner
 from ps2.parser.parser import Parser
@@ -16,7 +18,17 @@ class PS2:
         try:
             with open(fileName) as file:
                 lines = file.readlines()
+
+                start_dir = os.getcwd()
+
+                given_dir = os.path.dirname(fileName)
+                new_dir   = os.path.realpath(os.path.join(start_dir, given_dir))
+
+                os.chdir(new_dir)
+
                 PS2.run("".join(lines))
+
+                os.chdir(start_dir)
         except FileNotFoundError:
             print(f"Error: script '{fileName}' does not exist")
 

--- a/ps2/statement/statement.py
+++ b/ps2/statement/statement.py
@@ -1,3 +1,5 @@
+import os
+
 import abc
 import ps2.utilities as util
 
@@ -487,7 +489,10 @@ class OPENFILE( Statement ):
             raise RuntimeError([self.line, f"OPENFILE - unrecognised mode '{self.mode}'"])
 
         try:
-            file_id = open(name, mode)
+            cwd = os.getcwd()
+            file_path = os.path.realpath(os.path.join(cwd, name))
+
+            file_id = open(file_path, mode)
         except Exception as e:
             raise RuntimeError([self.line, f"unexpected error while executing OPENFILE {e}"])
 


### PR DESCRIPTION
Given:
```
main.py
└───files
    │   main.psc
    │   file.txt
```

In `files/main.psc`
```
DECLARE Line     : STRING
DECLARE FileName : STRING
FileName <- "file.txt"

OPENFILE FileName FOR READ

WHILE NOT EOF(FileName) DO
    READFILE FileName, Line

    OUTPUT Line
ENDWHILE

CLOSEFILE FileName
```
Running `.run files/main.psc`

Will output everything contained in `files/file.txt` rather than looking for `file.txt` in the base directory.