### PR TITLE
:bug: Fix error when assigning constants

### DIFF
--- a/ps2/parser/parser.py
+++ b/ps2/parser/parser.py
@@ -425,7 +425,7 @@ class Parser:
         if not self.match([TT.EQUAL]):
             raise SyntaxError([line, f"CONSTANT missing '=', got {self.peek().lexeme}"])
 
-        value = self.primary()
+        value = self.primary(line)
 
         if value == None:
             raise SyntaxError([line, f"CONSTANT missing a value"])


### PR DESCRIPTION
Fixes error that would occur when attempting to assign a value to a constant.

![image](https://user-images.githubusercontent.com/65423356/173188468-5fec65e7-1772-4bfe-b897-d703d8af5484.png)
